### PR TITLE
filter out living persons when searching for non-private fields

### DIFF
--- a/bhs_api/fsearch.py
+++ b/bhs_api/fsearch.py
@@ -40,9 +40,12 @@ def build_query(search_dict):
     # Set up optional queries
     sex = None
     individual_id = None
+    only_deceased = False
 
     # Sort all the arguments to those with name or place and those with year
     for k, v in search_dict.items():
+        if k.endswith('place') or '_year' in k:
+            only_deceased = True
         if k.endswith('name') or k.endswith('place'):
             # The search is case insensitive
             names_and_places[k] = v.lower()
@@ -142,6 +145,9 @@ def build_query(search_dict):
                 search_query['id'] = individual_id
         except ValueError:
             abort(400, 'Tree number must be an integer')
+
+    if only_deceased:
+        search_query["deceased"] = True
 
     return search_query
 

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -7,7 +7,7 @@ from bhs_api.fsearch import fsearch, clean_person
 # The documentation for client is at http://werkzeug.pocoo.org/docs/0.9/test/
 
 def test_fsearch_api(mock_db):
-    for i in  [{
+    for i in [{
             'name_lc': ['albert', 'einstein'],
             'deceased': True,
             'tree_num': 2,
@@ -22,11 +22,24 @@ def test_fsearch_api(mock_db):
             'tree_version': 1,
             'id': 'I7',
             'Slug': {'En': 'person_1;0.I7'},
-        } ]:
-        mock_db['persons'].insert(i)
+            'BIRT_PLAC_lc': "acapulco"
+        },{
+            'name_lc': ['cookie', 'monster'],
+            'deceased': False,
+            'tree_num': 2,
+            'tree_version': 1,
+            'id': 'I9',
+            'Slug': {'En': 'person_1;0.I9'},
+            'BIRT_PLAC_lc': "acapulco"
+        }]:
+            mock_db['persons'].insert(i)
     total, persons = fsearch(last_name=['Einstein'], db=mock_db)
     assert total == 1
     assert persons[0]['tree_version'] == 1
+    # searching with living person details should not return any living persons
+    total, persons = fsearch(birth_place=["Acapulco"], db=mock_db)
+    assert total == 1
+    assert persons[0]['id'] == "I7"
 
 def test_clean_person(mock_db):
     # two cases for cleaning up the personal info


### PR DESCRIPTION
When searching for places or years - search results will only contain dead people

#### related issues
* #94 