### PR TITLE
whitelist living person details - on both migrate and search

### DIFF
--- a/bhs_api/fsearch.py
+++ b/bhs_api/fsearch.py
@@ -1,10 +1,8 @@
 import logging
 import re
-from datetime import datetime
-
 from flask import abort, current_app
 from bhs_api import phonetic
-from bhs_api.utils import is_living_person
+from bhs_api.persons import is_living_person, LIVING_PERSON_WHITELISTED_KEYS
 
 MAX_RESULTS=30 # aka chunk size
 
@@ -208,6 +206,8 @@ def clean_person(person):
     ''' clean a person up. replace gedcom names with better names and clean
         details of the living.
     '''
+
+
     try:
         # mongo's id
         del person['_id']
@@ -216,12 +216,11 @@ def clean_person(person):
 
     # translating gedcom names
     for db_key, api_key in (('BIRT_PLAC', 'birth_place'),
-                     ('DEAT_PLAC', 'death_place'),
-                     ('MARR_PLAC', 'marriage_place'),
-                     ('MARR_DATE', 'marriage_date'),
-                     ('OCCU', 'occupation'),
-                     ('NOTE', 'bio'),
-                     ):
+                            ('DEAT_PLAC', 'death_place'),
+                            ('MARR_PLAC', 'marriage_place'),
+                            ('MARR_DATE', 'marriage_date'),
+                            ('OCCU', 'occupation'),
+                            ('NOTE', 'bio')):
         try:
             person[api_key] = person.pop(db_key)
         except KeyError:
@@ -230,9 +229,6 @@ def clean_person(person):
     # remove the details of the living
     if is_living_person(person.get('deceased'), person.get('birth_year')):
         for key in person.keys():
-            if key in ['birth_year', 'death_year', 'birth_place',
-                       'death_place', 'marriage_place', 'marriage_date',
-                       'occupation', 'bio', 'BIRT_DATE'
-                      ]:
+            if key not in LIVING_PERSON_WHITELISTED_KEYS:
                 del person[key]
     return person

--- a/bhs_api/persons.py
+++ b/bhs_api/persons.py
@@ -1,0 +1,37 @@
+"""
+logic and constants relating to persons
+"""
+import datetime
+
+
+LIVING_PERSON_WHITELISTED_KEYS = ["partners",
+                                  "name",
+                                  "name_S",
+                                  "tree_num",
+                                  "name_lc",
+                                  "tree_size",
+                                  "sex",
+                                  "parents",
+                                  "siblings",
+                                  "Slug",
+                                  "tree_file_id",
+                                  "id",
+                                  "deceased",
+                                  "tree_version"]
+
+
+def is_living_person(is_deceased, birth_year):
+    if is_deceased:
+        # deceased == not living!
+        return False
+    elif not isinstance(birth_year, (int, float)):
+        # doesn't have a valid birth year
+        # consider him as living (to be on the safe-side)
+        return True
+    elif datetime.datetime.now().year - int(birth_year) < 100:
+        # born less then 100 years ago
+        # consider him as living
+        return True
+    else:
+        # consider him as dead
+        return False

--- a/bhs_api/utils.py
+++ b/bhs_api/utils.py
@@ -380,20 +380,3 @@ def get_unit_type(collection_identifier):
     except KeyError:
         map_output = None
     return map_output
-
-
-def is_living_person(is_deceased, birth_year):
-    if is_deceased:
-        # deceased == not living!
-        return False
-    elif not isinstance(birth_year, (int, float)):
-        # doesn't have a valid birth year
-        # consider him as living (to be on the safe-side)
-        return True
-    elif datetime.datetime.now().year - int(birth_year) < 100:
-        # born less then 100 years ago
-        # consider him as living
-        return True
-    else:
-        # consider him as dead
-        return False

--- a/migration/family_trees.py
+++ b/migration/family_trees.py
@@ -109,6 +109,7 @@ class Gedcom2Persons:
                 for key in node:
                     if key not in LIVING_PERSON_WHITELISTED_KEYS:
                         del node[key]
+            ret.append(node)
         return ret if isinstance(nodes, collections.Iterable) else node
 
 

--- a/migration/family_trees.py
+++ b/migration/family_trees.py
@@ -8,7 +8,7 @@ import boto
 from bson.code import Code
 
 from .tasks import update_row, update_tree
-from bhs_api.utils import is_living_person
+from bhs_api.persons import is_living_person, LIVING_PERSON_WHITELISTED_KEYS
 
 THIS_YEAR = datetime.now().year
 # google storage: OUTPUT_BUCKET = 'bhs-familytrees-json'
@@ -104,7 +104,11 @@ class Gedcom2Persons:
                     node['death_year'] = e.death_year
                     node['marriage_years'] = e.marriage_years
                     add_children(e, None, node)
-            ret.append(node)
+            if not node['deceased']:
+                # it's alive! delete all keys not in the living person whitelist
+                for key in node:
+                    if key not in LIVING_PERSON_WHITELISTED_KEYS:
+                        del node[key]
         return ret if isinstance(nodes, collections.Iterable) else node
 
 

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -73,6 +73,7 @@ def test_clean_person(mock_db):
     assert 'bio' in cleaned
 
     # test case using year in float + with BIRT_DATE field
+    # also, testing unknown fields - should also be removed (we have white-list of fields for living persons)
     cleaned = clean_person({
             'name_lc': ['yossi', 'cohen'],
             'birth_year': float(datetime.now().year-70),
@@ -80,11 +81,14 @@ def test_clean_person(mock_db):
             'Slug': {'En': 'person_1;0.I1'},
             'bio': 'yossi is a big boy',
             'deceased': False,
-            'BIRT_DATE': "Jan 15, 1972"
+            'BIRT_DATE': "Jan 15, 1972",
+            "FOO": "bar"
         })
-    assert 'BIRT_DATE' not in cleaned
+    # ensure all fields are removed except the white-listed fields
+    assert sorted(cleaned) == ['Slug', 'deceased', 'id', 'name_lc']
 
     # deceased person should be deceased regardless of birth year
+    # also, ensure that unknown fields are not removed
     cleaned = clean_person({
         'name_lc': ['yossi', 'cohen'],
         'birth_year': float(datetime.now().year - 5),
@@ -92,9 +96,11 @@ def test_clean_person(mock_db):
         'Slug': {'En': 'person_1;0.I1'},
         'bio': 'yossi is a little dead boy',
         'deceased': True,
-        'BIRT_DATE': "Jan 15, 1972"
+        'BIRT_DATE': "Jan 15, 1972",
+        "FOO": "bar"
     })
     assert 'bio' in cleaned
+    assert "FOO" in cleaned
 
 
 def test_get_persons(client, mock_db):


### PR DESCRIPTION
* added LIVING_PERSON_WHITELISTED_KEYS constant - which contains only the person keys which are allowed for a living person
* both migrate and search results (clean_person) remove all keys not in this whitelist

#### Related issues
* #103 
* #98 
