### PR TITLE
API should return bagnowka images urls directed to AWS  (new)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ nohup.out
 error.log
 htmlcov
 .coverage
+/.vscode
+
 

--- a/bhs_api/item.py
+++ b/bhs_api/item.py
@@ -151,7 +151,6 @@ def fetch_item(slug, db=None):
     """
     Gets an item based on slug and returns it
     If slug is bad or item is not found, raises an exception.
-
     """
     if not db:
         db = current_app.data_db
@@ -201,10 +200,16 @@ def enrich_item(item, db=None, collection_name=None):
                     main_image_id = picture_id
 
         if main_image_id:
-            item['main_image_url'] = get_image_url(main_image_id,
-                                                current_app.conf.image_bucket)
-            item['thumbnail_url'] = get_image_url(main_image_id,
-                                            current_app.conf.thumbnail_bucket)
+            if item.has_key('bagnowka'):
+                # For bagnowka, thumbnail_bucket is the same as image_bucket (full sized images) because images are very small as it is
+                item['main_image_url'] = '{}/{}.jpg'.format(current_app.conf.bagnowka_bucket_url, main_image_id)
+                item['thumbnail_url'] = '{}/{}.jpg'.format(current_app.conf.bagnowka_bucket_url, main_image_id)
+            else:
+                image_bucket = current_app.conf.image_bucket
+                thumbnail_bucket = current_app.conf.thumbnail_bucket
+                item['main_image_url'] = get_image_url(main_image_id, image_bucket)
+                item['thumbnail_url'] = get_image_url(main_image_id, thumbnail_bucket)
+            
     video_id_key = 'MovieFileId'
     if video_id_key in item:
         # Try to fetch the video URL

--- a/conf/app_server.yaml
+++ b/conf/app_server.yaml
@@ -24,6 +24,7 @@ email_password: 19782013
 email_from: info@bh.org.il
 
 # Bucket urls
+bagnowka_bucket_url: https://s3-us-west-2.amazonaws.com/bagnowka-scraped/full
 image_bucket: bhs-flat-pics
 thumbnail_bucket: bhs-thumbnails
 ftree_bucket_url: https://storage.googleapis.com/bhs-familytrees


### PR DESCRIPTION
(#165 updated)
**Overview**
- All DBSs images (from bhp) are stored in google storage, and the API returned `main_image_url` to gcs. 
- New photoUnits will be added to BH DBS from external sources, starting scraped images from "www.bagnowka.pl" images.  
- Bagnowka images are stored in AWS
- in order to get the correct URLs for the images stored in AWS s3, the API should identify these items, and set the `main_image_url` and `thumbnail_url` to direct to AWS, instead of the default gcs storage.

(See #146)

**Applied Changes** 
- Updated **item.py**: changed `enrich_item` to identify bagnowka images and return correct `main_image_url` and `thumbnail_url` - now leading to AWS s3.
- Updated **v1_endpoints.py** `@v1_endpoints.route('/search')` to show error log messages.
- Added AWS bucket to **app_server.yaml**