### PR TITLE
# 183 Update test_migration

### DIFF
--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -267,6 +267,7 @@ def test_ensure_metadata(app, mock_db):
     assert [h["person_id"] for h in es_search(app, "persons", "person_id:I2")] == []
     # living person in ES - deleted
     assert [h["person_id"] for h in es_search(app, "persons", "person_id:I687")] == []
+    assert [h["person_id"] for h in es_search(app, "persons", "person_id:I686")] == []
     # person has first_name / last_name fields (added during migration process for elasticsearch indexing)
     assert [h["first_name_lc"] for h in es_search(app, "persons", "person_id:I3")] == ["deady"]
     assert [h["last_name_lc"] for h in es_search(app, "persons", "person_id:I3")] == ["deadead"]


### PR DESCRIPTION
- Tests failed due to added items in elasticsearch, which are only needed for some tests.
- Modified `ensuretest_ensure_metadata()`, all tests pass locally (see exception in comments)
