### PR TITLE
get item API returns related documents

### DIFF
--- a/bhs_api/v1_endpoints.py
+++ b/bhs_api/v1_endpoints.py
@@ -549,7 +549,7 @@ def get_items(slugs):
     except NotFound, e:
         return humanify({"error": str(e)}, 404)
     except Exception, e:
-        return humanify({"error": "unexpected exception getting completion data: {}".format(e), "traceback": traceback.format_exc()}, 500)
+        return humanify({"error": "unexpected exception getting items from slugs {}: {}".format(slugs, str(e)), "traceback": traceback.format_exc()}, 500)
     # TODO: check what's needed for ugc items
     # Check if there are items from ugc collection and test their access control
     # ugc_items = []


### PR DESCRIPTION
fixes #207 
  * added `related_documents` field to get item API response
  * it contains dict of related document categories (source dependant), each with the related documents data (as received for search results)